### PR TITLE
docs: fix links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,10 @@ To install the required dependencies and run this Java app -
 $ ./gradlew run
 ```
 
-Once your server is up and running, you can authenticate your vehicle. In our current set up, we are using Smartcar's [test mode](https://smartcar.com), so you can log in with any username and password. To authenticate, navigate to `http://localhost:8000/login`. Once you have authenticated, go to `http://localhost:8000/vehicle` to see your vehicle information.
+Once your server is up and running, you can authenticate your vehicle. In our current set up, we are using Smartcar's [test mode](https://smartcar.com/docs/guides/testing/), so you can log in with any username and password. To authenticate, navigate to `http://localhost:8000/login`. Once you have authenticated, go to `http://localhost:8000/vehicle` to see your vehicle information.
 
 ## Next Steps
-Read our [API Docs](https://smartcar.com/docs) to learn what else you can do with Smartcar's API.
+Read our [API Docs](https://smartcar.com/docs/api) to learn what else you can do with Smartcar's API.
 
 Learn more about the [Java SDK](https://github.com/smartcar/java-sdk) and how it can be used.
 


### PR DESCRIPTION
```
[I] ➜ markdown-link-check README.md

FILE: README.md
[✓] https://smartcar.com/docs/guides/testing/
[✓] https://smartcar.com/docs/api
[✓] https://github.com/smartcar/java-sdk
```